### PR TITLE
Feature/snapshots frontend

### DIFF
--- a/app/javascript/css/application.css
+++ b/app/javascript/css/application.css
@@ -27,3 +27,10 @@ body {
   padding: 2em;
   background-color: #fff;
 }
+
+.inspector-content {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  height: 1.2em;
+  white-space: nowrap;
+}

--- a/app/javascript/packs/graph.jsx
+++ b/app/javascript/packs/graph.jsx
@@ -15,7 +15,8 @@ const D3_GRAPH_CONFIG = {
     highlightStrokeColor: 'blue',
   },
   link: {
-    highlightColor: '#efefef',
+    highlightColor: '#000',
+    strokeWidth: 4,
   },
 }
 

--- a/app/javascript/packs/graph.jsx
+++ b/app/javascript/packs/graph.jsx
@@ -56,8 +56,7 @@ Inspector.propTypes = {
 const App = ({ snapshot }) => {
   const [currentSource, setCurrentSource] = React.useState()
   const [currentTarget, setCurrentTarget] = React.useState()
-
-  const topics = 'Cheese and Wine' // FIXME
+  const [currentTopics, setCurrentTopics] = React.useState()
 
   const handleClickNode = _nodeId => {}
 
@@ -70,11 +69,13 @@ const App = ({ snapshot }) => {
   const handleMouseOverLink = (source, target) => {
     setCurrentSource(source)
     setCurrentTarget(target)
+    setCurrentTopics(snapshot.links.find(l => l.source === source && l.target === target).topics);
   }
 
   const handleMouseOutLink = (_source, _target) => {
     setCurrentSource(undefined)
     setCurrentTarget(undefined)
+    setCurrentTopics(undefined)
   }
 
   return (
@@ -83,7 +84,7 @@ const App = ({ snapshot }) => {
         <Inspector
           source={currentSource}
           target={currentTarget}
-          topics={topics}
+          topics={currentTopics}
         />
       </div>
       <Graph
@@ -107,8 +108,9 @@ App.propTypes = {
 const DUMMY_SNAPSHOT = {
   nodes: [{ id: 'Harry' }, { id: 'Sally' }, { id: 'Alice' }],
   links: [
-    { source: 'Harry', target: 'Sally' },
-    { source: 'Harry', target: 'Alice' },
+    { source: 'Harry', target: 'Sally', topics: 'Topic1 and Topic5' },
+    { source: 'Harry', target: 'Alice', topics: 'Topic2 and Topic6' },
+    { source: 'Sally', target: 'Alice', topics: 'Topic3 and Topic7' },
   ],
 }
 

--- a/app/javascript/packs/graph.jsx
+++ b/app/javascript/packs/graph.jsx
@@ -37,7 +37,7 @@ const SnapshotShape = PropTypes.shape({
 
 // components
 const Inspector = ({ source, target, topics }) => (
-  <p>
+  <p className="inspector-content">
     {source && target ? (
       <span>
         <strong>{source}</strong> and <strong>{target}</strong> chatted about{' '}


### PR DESCRIPTION
1. When hovering a graph link, display the emails of the 2 nodes involved and the topics from their conversations.
2. Improve UI. Thicker lines for the graph links, easier to hover and stay on them with the mouse.
3. Improve UI. Set fixed height for Inspector and truncate topics if too long. (Dynamic height would displace the graph downwards, oftentimes cancelling the mouse-hover).

<kbd>
<img src='https://github.com/user-attachments/assets/f56b2899-415e-43ea-a54b-1bbd3da3b7e2' width=300 />
</kbd>